### PR TITLE
Elixir Fips 140-2 Compliant Container 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Ignore IDEA files
+.idea
+
+# Ignore Mac cruft
+**/.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM ninefx/erlang-fips:20.3.4
+FROM ninefx/erlang-fips:22.3
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.6.4" \
+ENV ELIXIR_VERSION="v1.10.2" \
     LANG=C.UTF-8
 
 RUN set -xe \


### PR DESCRIPTION
Originally, this Docker image was not FIPS compliant. This is what we are trying to implement.  